### PR TITLE
fix: properly add deploy-guides entries to listing

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -10,7 +10,7 @@ listing:
     contents:
       - repairs
       - retro-sdks
-      - dev-guides
+      - deploy-guides
     fields: [image, date, title, description, author, reading-time]
     sort:
       - "date desc"


### PR DESCRIPTION
**DESCRIPTION:** Category `deploy-guides` wasn't properly defined in the `index.qmd` listing